### PR TITLE
Use standard __ANDROID__ preprocessor macro

### DIFF
--- a/include/event2/event-config.h
+++ b/include/event2/event-config.h
@@ -446,7 +446,7 @@
 /* #undef _EVENT_inline */
 #endif
 
-#ifdef ANDROID
+#ifdef __ANDROID__
 typedef int fd_mask;
 #endif
 


### PR DESCRIPTION
Other suggestions:

1. Make `shadowsocks-android` the default branch;
2. Upstream of current branch is `patch-2.0` branch, maybe consider updating to the latest stable release?